### PR TITLE
Se añaden reglas de linting al front end 

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -45,7 +45,11 @@
         {
           "invalid-first-character-of-tag-name": false
         }
-      ]
+      ],
+      "no-async-promise-executor": 1,
+      "no-unused-vars": 1,
+      "no-unexpected-multiline": 1,
+      "no-undef": 1
     }
   },
   "browserslist": [


### PR DESCRIPTION
Se añaden reglas necesarias para que el mapa no tire errores de compilación por reglas de linting, las adiciones ocurrieron en package.json