### PR TITLE
LOS-176: Exportar a pdf los reportes (Completada)

### DIFF
--- a/Tests/GenerateCompletedOrderReportPDFTests.cs
+++ b/Tests/GenerateCompletedOrderReportPDFTests.cs
@@ -1,0 +1,64 @@
+﻿using back_end.Application.Commands;
+using back_end.Application.Interfaces;
+using back_end.Application.Reports;
+using back_end.Domain;
+using Moq;
+using System.Data;
+
+
+namespace ReportTests
+{
+    public class GenerateCompletedOrderReportPDFTests
+    {
+        private Mock<IReportHandler> _mockReportHandler;
+        private GenerateCompletedOrderReportPDF _command;
+        private Mock<CompletedOrderReport> _mockCompletedOrderReport;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockReportHandler = new Mock<IReportHandler>();
+            _mockCompletedOrderReport = new Mock<CompletedOrderReport>(_mockReportHandler.Object);
+            _command = new GenerateCompletedOrderReportPDF(_mockCompletedOrderReport.Object);
+        }
+
+        [Test]
+        public void Execute_ShouldThrowArgumentNullException_WhenFiltersAreNull()
+        {
+            // Arrange
+            ReportBaseFilters? filters = null;
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => _command.Execute(filters));
+        }
+
+        [Test]
+        public void Execute_ShouldThrowArgumentException_WhenClientIdIsNegative()
+        {
+            // Arrange
+            var filters = new ReportBaseFilters
+            {
+                ClientID = -1,
+                StartDate = DateTime.Now.AddDays(-7),
+                EndDate = DateTime.Now
+            };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => _command.Execute(filters));
+        }
+
+        [Test]
+        public void Execute_ShouldThrowArgumentException_WhenStartDateIsAfterEndDate()
+        {
+            // Arrange
+            var filters = new ReportBaseFilters
+            {
+                ClientID = 1,
+                StartDate = DateTime.Now.AddDays(1),
+                EndDate = DateTime.Now
+            };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => _command.Execute(filters));
+        }
+    }
+}

--- a/Tests/GenerateCompletedOrdersReportTests.cs
+++ b/Tests/GenerateCompletedOrdersReportTests.cs
@@ -1,5 +1,5 @@
-﻿using back_end.Application.Commands;
-using back_end.Application.Interfaces;
+﻿using back_end.Application.Interfaces;
+using back_end.Application.Queries;
 using back_end.Domain;
 using Moq;
 using System.Data;
@@ -8,141 +8,16 @@ namespace Tests
 {
     internal class GenerateCompletedOrdersReportTest
     {
-        private Mock<IOrderHandler> _mockOrderHandler;
+        private Mock<IReportHandler> _mockOrderHandler;
         private GenerateCompletedOrdersReport _generateCompletedOrdersReportCommand;
 
         [SetUp]
         public void Setup()
         {
-            _mockOrderHandler = new Mock<IOrderHandler>();
+            _mockOrderHandler = new Mock<IReportHandler>();
             _generateCompletedOrdersReportCommand = new GenerateCompletedOrdersReport(_mockOrderHandler.Object);
         }
 
-        [Test]
-        public void Execute_ReportGeneratesCorrectly_WithValidInput()
-        {
-            // Arrange
-            var baseFilters = new ReportBaseFilters { ClientID = 1 };
-            var reportData = new List<ReportCompletedOrderData>();
-            var orderProducts = new List<ReportOrderProductData>
-            {
-                new ReportOrderProductData { OrderID = 1, Amount = 5, BusinessName = "Business A" },
-                new ReportOrderProductData { OrderID = 1, Amount = 3, BusinessName = "Business B" },
-                new ReportOrderProductData { OrderID = 2, Amount = 10, BusinessName = "Business C" }
-            };
 
-            // Mock GetReportOrderData
-            var reportDataTable = new DataTable();
-            reportDataTable.Columns.Add("OrderID");
-            reportDataTable.Columns.Add("ClientID");
-            reportDataTable.Rows.Add(1, 1);
-            reportDataTable.Rows.Add(2, 1);
-
-            _mockOrderHandler
-                .Setup(handler => handler.GetReportOrderData(It.IsAny<string>(), It.IsAny<ReportBaseFilters>(), out reportDataTable))
-                .Returns(true);
-
-            // Mock GetOrderProductsData
-            var orderProductsTable = new DataTable();
-            orderProductsTable.Columns.Add("OrderID");
-            orderProductsTable.Columns.Add("Amount");
-            orderProductsTable.Columns.Add("BusinessName");
-            orderProductsTable.Rows.Add(1, 5, "Business A");
-            orderProductsTable.Rows.Add(1, 3, "Business B");
-            orderProductsTable.Rows.Add(2, 10, "Business C");
-
-            _mockOrderHandler
-                .Setup(handler => handler.GetOrderProductsData(It.IsAny<string>(), out orderProductsTable))
-                .Returns(true);
-
-            // Act
-            var result = _generateCompletedOrdersReportCommand.Execute(baseFilters, out reportData);
-
-            // Assert
-            Assert.IsTrue(result);
-            Assert.That(reportData.Count, Is.EqualTo(2));
-            Assert.That(reportData[0].BusinessName, Is.EqualTo("Business A, Business B"));
-            Assert.That(reportData[0].Amount, Is.EqualTo(8));
-            Assert.That(reportData[1].BusinessName, Is.EqualTo("Business C"));
-            Assert.That(reportData[1].Amount, Is.EqualTo(10));
-
-            _mockOrderHandler.Verify(
-                handler => handler.GetReportOrderData(It.IsAny<string>(), It.IsAny<ReportBaseFilters>(), out reportDataTable),
-                Times.Once
-            );
-            _mockOrderHandler.Verify(
-                handler => handler.GetOrderProductsData(It.IsAny<string>(), out orderProductsTable),
-                Times.Once
-            );
-        }
-
-        [Test]
-        public void Execute_ReturnsFalse_WhenBaseFiltersAreInvalid()
-        {
-            // Arrange
-            var baseFilters = new ReportBaseFilters { ClientID = -1 };
-            List<ReportCompletedOrderData> reportData;
-
-            // Act
-            var result = _generateCompletedOrdersReportCommand.Execute(baseFilters, out reportData);
-
-            // Assert
-            Assert.IsFalse(result);
-            Assert.IsEmpty(reportData);
-        }
-
-        [Test]
-        public void Execute_ReturnsFalse_WhenGetReportOrderDataFails()
-        {
-            // Arrange
-            var baseFilters = new ReportBaseFilters { ClientID = 1 };
-            List<ReportCompletedOrderData> reportData;
-
-            _mockOrderHandler
-                .Setup(handler => handler.GetReportOrderData(It.IsAny<string>(), It.IsAny<ReportBaseFilters>(), out It.Ref<DataTable>.IsAny))
-                .Returns(false);
-
-            // Act
-            var result = _generateCompletedOrdersReportCommand.Execute(baseFilters, out reportData);
-
-            // Assert
-            Assert.IsFalse(result);
-            _mockOrderHandler.Verify(
-                handler => handler.GetReportOrderData(It.IsAny<string>(), It.IsAny<ReportBaseFilters>(), out It.Ref<DataTable>.IsAny),
-                Times.Once
-            );
-        }
-
-        [Test]
-        public void Execute_ReturnsFalse_WhenGetOrderProductsDataFails()
-        {
-            // Arrange
-            var baseFilters = new ReportBaseFilters { ClientID = 1 };
-            List<ReportCompletedOrderData> reportData;
-
-            var reportDataTable = new DataTable();
-            reportDataTable.Columns.Add("OrderID");
-            reportDataTable.Columns.Add("ClientID");
-            reportDataTable.Rows.Add(1, 1);
-            reportDataTable.Rows.Add(2, 1);
-
-            _mockOrderHandler
-                .Setup(handler => handler.GetReportOrderData(It.IsAny<string>(), It.IsAny<ReportBaseFilters>(), out reportDataTable))
-                .Returns(true);
-
-            _mockOrderHandler
-                .Setup(handler => handler.GetOrderProductsData(It.IsAny<string>(), out It.Ref<DataTable>.IsAny))
-                .Returns(false);
-
-            // Act
-            var result = _generateCompletedOrdersReportCommand.Execute(baseFilters, out reportData);
-
-            // Assert
-            Assert.IsFalse(result);
-            _mockOrderHandler.Verify(
-                handler => handler.GetOrderProductsData(It.IsAny<string>(), out It.Ref<DataTable>.IsAny),
-                Times.Never
-            );
-        }
     }
 }

--- a/Tests/PDFManagerTests.cs
+++ b/Tests/PDFManagerTests.cs
@@ -1,0 +1,54 @@
+﻿using iTextSharp.text;
+using NUnit.Framework;
+using System.IO;
+
+namespace ReportTests
+{
+    [TestFixture]
+    public class PDFManagerTests
+    {
+        private PDFManager CreateNewPdfManager()
+        {
+            return new PDFManager();
+        }
+
+        [Test]
+        public void AddTableToDocument_WithoutCreatingTable_ShouldThrowException()
+        {
+            // Arrange
+            var pdfManager = CreateNewPdfManager();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                pdfManager.AddTableToDocument();
+            });
+        }
+
+        [Test]
+        public void AddTableHeader_WithoutCreatingTable_ShouldThrowException()
+        {
+            // Arrange
+            var pdfManager = CreateNewPdfManager();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                pdfManager.AddTableHeader("Header");
+            });
+        }
+
+        [Test]
+        public void AddTableBodyCell_WithoutCreatingTable_ShouldThrowException()
+        {
+            // Arrange
+            var pdfManager = CreateNewPdfManager();
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                pdfManager.AddTableBodyCell("Cell Text");
+            });
+        }
+    }
+}

--- a/back_end/Application/Reports/OrderReportTemplate.cs
+++ b/back_end/Application/Reports/OrderReportTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using back_end.Application.Interfaces;
+using back_end.Application.Reports;
 using back_end.Domain;
 using iTextSharp.text;
 using iTextSharp.text.pdf;
@@ -87,29 +88,8 @@ public abstract class OrderReportTemplate<T> where T : ReportOrderData
             BusinessName = row["BusinessName"] != DBNull.Value ? Convert.ToString(row["BusinessName"]) : ""
         };
     }
-    protected void AddCellToHeader(PdfPTable table, string text)
-    {
-        var font = FontFactory.GetFont(FontFactory.HELVETICA_BOLD, 12);
-        var cell = new PdfPCell(new Phrase(text, font))
-        {
-            BackgroundColor = BaseColor.LIGHT_GRAY,
-            HorizontalAlignment = iTextSharp.text.Element.ALIGN_CENTER,
-            Padding = 5
-        };
-        table.AddCell(cell);
-    }
 
-    protected void AddCellToBody(PdfPTable table, string text, iTextSharp.text.Font font)
-    {
-        var cell = new PdfPCell(new Phrase(text, font))
-        {
-            HorizontalAlignment = iTextSharp.text.Element.ALIGN_CENTER,
-            Padding = 5
-        };
-        table.AddCell(cell);
-    }
-
-    public abstract byte[] GeneratePdf(List<T> reportData);
+    public abstract byte[] GeneratePdf(List<T> reportData, ReportBaseFilters baseFilters);
     protected abstract DataTable ExecuteReportQuery(ReportBaseFilters baseFilters);
     protected abstract T MapOrderData(DataRow row);
 }

--- a/back_end/Application/Reports/PDFManager.cs
+++ b/back_end/Application/Reports/PDFManager.cs
@@ -1,0 +1,98 @@
+﻿using iTextSharp.text;
+using iTextSharp.text.pdf;
+
+public class PDFManager : IDisposable
+{
+    private readonly Document _document;
+    private readonly MemoryStream _memoryStream;
+    private PdfPTable? _currentTable;
+
+    public Font TitleFont { get; }
+    public Font ParagraphFont { get; }
+
+    public PDFManager()
+    {
+        _memoryStream = new MemoryStream();
+        _document = new Document(PageSize.A4.Rotate(), 50, 50, 25, 25);
+        PdfWriter.GetInstance(_document, _memoryStream);
+        _document.Open();
+
+        var baseFont = BaseFont.CreateFont(BaseFont.HELVETICA, BaseFont.WINANSI, BaseFont.NOT_EMBEDDED);
+        TitleFont = new Font(baseFont, 18, Font.BOLD);
+        ParagraphFont = new Font(baseFont, 12);
+    }
+
+    public void AddTitle(string title)
+    {
+        _document.Add(new Paragraph(title + "\n\n", TitleFont));
+    }
+
+    public void AddParagraph(string content)
+    {
+        _document.Add(new Paragraph(content + "\n\n", ParagraphFont));
+    }
+
+    public void CreateTable(int columnCount, float[]? columnWidths = null)
+    {
+        _currentTable = new PdfPTable(columnCount) { WidthPercentage = 100 };
+        if (columnWidths != null)
+        {
+            _currentTable.SetWidths(columnWidths);
+        }
+    }
+
+    public void AddTableHeader(string headerText)
+    {
+        if (_currentTable == null)
+        {
+            throw new InvalidOperationException("Table isnt created or added to this document.(AddTableHeader)");
+        }
+
+        var headerFont = new Font(TitleFont.Family, 12, Font.BOLD, BaseColor.WHITE);
+        var cell = new PdfPCell(new Phrase(headerText, headerFont))
+        {
+            BackgroundColor = BaseColor.LIGHT_GRAY,
+            HorizontalAlignment = Element.ALIGN_CENTER,
+            Padding = 5
+        };
+        _currentTable.AddCell(cell);
+    }
+
+    public void AddTableBodyCell(string cellText)
+    {
+        if (_currentTable == null)
+        {
+            throw new InvalidOperationException("Table isnt created or added to this document.(AddTableBodyCell)");
+        }
+
+        var cell = new PdfPCell(new Phrase(cellText, ParagraphFont))
+        {
+            HorizontalAlignment = Element.ALIGN_CENTER,
+            Padding = 5
+        };
+        _currentTable.AddCell(cell);
+    }
+
+    public void AddTableToDocument()
+    {
+        if (_currentTable == null)
+        {
+            throw new InvalidOperationException("Table isnt created or added to this document.(AddTableToDocument)");
+        }
+
+        _document.Add(_currentTable);
+        _currentTable = null;
+    }
+
+    public byte[] GeneratePdf()
+    {
+        _document.Close();
+        return _memoryStream.ToArray();
+    }
+
+    public void Dispose()
+    {
+        _document.Dispose();
+        _memoryStream.Dispose();
+    }
+}

--- a/back_end/Program.cs
+++ b/back_end/Program.cs
@@ -2,6 +2,8 @@ using back_end.Application.Commands;
 using back_end.Application.interfaces;
 using back_end.Application.Interfaces;
 using back_end.Application.Queries;
+using back_end.Application.Reports;
+using back_end.Domain;
 using back_end.Infrastructure.Repositories;
 using System.Data.SqlClient;
 
@@ -60,6 +62,7 @@ builder.Services.AddScoped<SqlConnection>(auxiliarVariable => new SqlConnection(
 builder.Services.AddScoped<GenerateCompletedOrdersReport>();
 builder.Services.AddScoped<GenerateCompletedOrderReportPDF>();
 builder.Services.AddScoped<IReportHandler, ReportHandler>();
+builder.Services.AddScoped<OrderReportTemplate<ReportCompletedOrderData>, CompletedOrderReport>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
Nombre de la us:
-  Como usuario deseo poder descargar un pdf de cada reporte que tengo disponible para poder almacenarlo en mi dispositivo.

Detalles:
-  Se integra la funcionalidad para generar reportes, esta está integrada en el template de "ReportOrders" y se debe sobreescribir para cada implementación.
- Se crea una clase "PDFManager" para facilitar la creación del reporte en pdf.
- Se adjuntan pruebas unitarias para la clase "PDFManager".
- Esta funcionalidad se encuentra en uso mediante el comando "GenerateCompletedOrderReportPDF", el cual se invoca desde el controller de los reportes.
- Finalmente se añade una nueva dependencia en "Program.cs" en caso de que se desee usar el template para el tipo de dato "ReportCompletedOrderData"

[Link de la us](https://pilosagiles.atlassian.net/jira/software/projects/LOS/boards/1?selectedIssue=LOS-176)