### PR TITLE
LOS161 Reporte de ordenes rechazadas para admin

### DIFF
--- a/Tests/GenerateAllCancelledOrderReportPDFTests.cs
+++ b/Tests/GenerateAllCancelledOrderReportPDFTests.cs
@@ -1,0 +1,41 @@
+﻿using back_end.Application.Commands;
+using back_end.Application.Interfaces;
+using back_end.Application.Reports;
+using back_end.Domain;
+using Moq;
+
+namespace Tests {
+    internal class GenerateAllCancelledOrderReportPDFTests {
+        private Mock<IReportHandler> _mockReportHandler;
+        private GenerateAllCancelledOrderReportPDF _command;
+        private Mock<AllCancelledOrderReport> _mockAllCancelledOrderReport;
+
+        [SetUp]
+        public void SetUp() {
+            _mockReportHandler = new Mock<IReportHandler>();
+            _mockAllCancelledOrderReport = new Mock<AllCancelledOrderReport>(_mockReportHandler.Object);
+            _command = new GenerateAllCancelledOrderReportPDF(_mockAllCancelledOrderReport.Object);
+        }
+
+        [Test]
+        public void Execute_ShouldThrowArgumentNullException_WhenFiltersAreNull() {
+            // Arrange
+            ReportBaseFilters? filters = null;
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => _command.Execute(filters));
+        }
+
+        [Test]
+        public void Execute_ShouldThrowArgumentException_WhenStartDateIsAfterEndDate() {
+            // Arrange
+            var filters = new ReportBaseFilters {
+                ClientID = 0,
+                StartDate = DateTime.Now.AddDays(1),
+                EndDate = DateTime.Now
+            };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => _command.Execute(filters));
+        }
+    }
+}

--- a/back_end/APIS/ReportsController.cs
+++ b/back_end/APIS/ReportsController.cs
@@ -62,5 +62,51 @@ namespace back_end.APIS
                 return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
             }
         }
+
+        [HttpGet("CancelledOrders")]
+        public ActionResult GenerateAllCancelledOrdersReport(
+            string startDate, string endDate,
+            [FromServices] GenerateAllCancelledOrdersReport generateAllCancelledOrdersReport) {
+            try {
+
+                if (!DateTime.TryParse(startDate, out var start) || !DateTime.TryParse(endDate, out var end)) {
+                    return BadRequest("Invalid date format.");
+                }
+
+                var baseFilters = new ReportBaseFilters {
+                    ClientID = 0,
+                    StartDate = start,
+                    EndDate = end
+                };
+                return Ok(generateAllCancelledOrdersReport.Execute(baseFilters));
+            }
+            catch (SqlException sqlEx) {
+                return StatusCode(StatusCodes.Status500InternalServerError, sqlEx.Message);
+            }
+            catch (Exception ex) {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
+        [HttpGet("CancelledOrders/pdf")]
+        public ActionResult AllCancelledOrdersReportPDF(
+            string startDate, string endDate,
+            [FromServices] GenerateAllCancelledOrderReportPDF generateAllCancelledOrderReportPDF) {
+            try {
+
+                if (!DateTime.TryParse(startDate, out var start) || !DateTime.TryParse(endDate, out var end)) {
+                    return BadRequest("Invalid date format.");
+                }
+
+                var baseFilters = new ReportBaseFilters {
+                    ClientID = 0,
+                    StartDate = start,
+                    EndDate = end
+                };
+                return File(generateAllCancelledOrderReportPDF.Execute(baseFilters), "application/pdf", "AllCancelledOrdersReport(" + DateTime.Now.ToLongDateString() + ").pdf");
+            }
+            catch (Exception ex) {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
     }
 }

--- a/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
+++ b/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
@@ -1,0 +1,44 @@
+﻿using back_end.Application.Interfaces;
+using back_end.Application.Reports;
+using back_end.Domain;
+
+namespace back_end.Application.Commands
+{
+    public class GenerateAllCancelledOrderReportPDF
+    {
+        private readonly CancelledOrderReport cancelledOrderReport;
+        public GenerateAllCancelledOrderReportPDF(
+            IReportHandler reportHandler)
+        {
+            cancelledOrderReport = new CancelledOrderReport(reportHandler);
+        }
+
+        public byte[] Execute(ReportBaseFilters baseFilters)
+        {
+            if (baseFilters == null)
+                throw new ArgumentNullException(nameof(baseFilters), "Base filters cannot be null.");
+            if (baseFilters.StartDate > baseFilters.EndDate)
+                throw new ArgumentException("StartDate cannot be later than EndDate.", nameof(baseFilters));
+            List<AdminReportOrderData> reportData = cancelledOrderReport.FetchReportOrders(baseFilters);
+
+            if (reportData.Count > 0)
+            {
+                string orderIDs = cancelledOrderReport.GetOrderIDsFromReport(reportData.AsEnumerable());
+                List<ReportOrderProductData> orderProducts = cancelledOrderReport.FetchOrderProducts(orderIDs);
+                foreach (var cancelledOrder in reportData)
+                {
+                    var productsForCurrentOrder = orderProducts
+                        .Where(product => product.OrderID == cancelledOrder.OrderID)
+                        .ToList();
+
+                    cancelledOrder.BusinessName = string.Join(", ", productsForCurrentOrder
+                        .Select(product => product.BusinessName)
+                        .Distinct());
+
+                    cancelledOrder.Amount = productsForCurrentOrder.Sum(product => product.Amount);
+                }
+            }
+            return cancelledOrderReport.GeneratePdf(reportData);
+        }
+    }
+}

--- a/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
+++ b/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
@@ -6,11 +6,11 @@ namespace back_end.Application.Commands
 {
     public class GenerateAllCancelledOrderReportPDF
     {
-        private readonly CancelledOrderReport cancelledOrderReport;
+        private readonly AllCancelledOrderReport cancelledOrderReport;
         public GenerateAllCancelledOrderReportPDF(
             IReportHandler reportHandler)
         {
-            cancelledOrderReport = new CancelledOrderReport(reportHandler);
+            cancelledOrderReport = new AllCancelledOrderReport(reportHandler);
         }
 
         public byte[] Execute(ReportBaseFilters baseFilters)

--- a/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
+++ b/back_end/Application/Commands/GenerateAllCancelledOrderReportPDF.cs
@@ -6,11 +6,11 @@ namespace back_end.Application.Commands
 {
     public class GenerateAllCancelledOrderReportPDF
     {
-        private readonly AllCancelledOrderReport cancelledOrderReport;
+        private readonly OrderReportTemplate<AdminReportOrderData> _cancelledOrderReport;
         public GenerateAllCancelledOrderReportPDF(
-            IReportHandler reportHandler)
+            OrderReportTemplate<AdminReportOrderData> reportHandler)
         {
-            cancelledOrderReport = new AllCancelledOrderReport(reportHandler);
+            _cancelledOrderReport = reportHandler;
         }
 
         public byte[] Execute(ReportBaseFilters baseFilters)
@@ -19,12 +19,12 @@ namespace back_end.Application.Commands
                 throw new ArgumentNullException(nameof(baseFilters), "Base filters cannot be null.");
             if (baseFilters.StartDate > baseFilters.EndDate)
                 throw new ArgumentException("StartDate cannot be later than EndDate.", nameof(baseFilters));
-            List<AdminReportOrderData> reportData = cancelledOrderReport.FetchReportOrders(baseFilters);
+            List<AdminReportOrderData> reportData = _cancelledOrderReport.FetchReportOrders(baseFilters);
 
             if (reportData.Count > 0)
             {
-                string orderIDs = cancelledOrderReport.GetOrderIDsFromReport(reportData.AsEnumerable());
-                List<ReportOrderProductData> orderProducts = cancelledOrderReport.FetchOrderProducts(orderIDs);
+                string orderIDs = _cancelledOrderReport.GetOrderIDsFromReport(reportData.AsEnumerable());
+                List<ReportOrderProductData> orderProducts = _cancelledOrderReport.FetchOrderProducts(orderIDs);
                 foreach (var cancelledOrder in reportData)
                 {
                     var productsForCurrentOrder = orderProducts
@@ -37,8 +37,9 @@ namespace back_end.Application.Commands
 
                     cancelledOrder.Amount = productsForCurrentOrder.Sum(product => product.Amount);
                 }
+                return _cancelledOrderReport.GeneratePdf(reportData, baseFilters);
             }
-            return cancelledOrderReport.GeneratePdf(reportData);
+            return new byte[0];
         }
     }
 }

--- a/back_end/Application/Queries/GenerateAllCancelledOrdersReport.cs
+++ b/back_end/Application/Queries/GenerateAllCancelledOrdersReport.cs
@@ -1,0 +1,38 @@
+﻿using back_end.Application.Interfaces;
+using back_end.Application.Reports;
+using back_end.Domain;
+
+namespace back_end.Application.Queries {
+    public class GenerateAllCancelledOrdersReport {
+        private readonly CancelledOrderReport cancelledOrderReport;
+        public GenerateAllCancelledOrdersReport(
+            IReportHandler reportHandler) {
+            cancelledOrderReport = new CancelledOrderReport(reportHandler);
+        }
+
+        public List<AdminReportOrderData> Execute(ReportBaseFilters baseFilters) {
+            if (baseFilters == null)
+                throw new ArgumentNullException(nameof(baseFilters), "Base filters cannot be null.");
+            if (baseFilters.StartDate > baseFilters.EndDate)
+                throw new ArgumentException("StartDate cannot be later than EndDate.", nameof(baseFilters));
+            List<AdminReportOrderData> reportData = cancelledOrderReport.FetchReportOrders(baseFilters);
+
+            if (reportData.Count > 0) {
+                string orderIDs = cancelledOrderReport.GetOrderIDsFromReport(reportData.AsEnumerable());
+                List<ReportOrderProductData> orderProducts = cancelledOrderReport.FetchOrderProducts(orderIDs);
+                foreach (var cancelledOrder in reportData) {
+                    var productsForCurrentOrder = orderProducts
+                        .Where(product => product.OrderID == cancelledOrder.OrderID)
+                        .ToList();
+
+                    cancelledOrder.BusinessName = string.Join(", ", productsForCurrentOrder
+                        .Select(product => product.BusinessName)
+                        .Distinct());
+
+                    cancelledOrder.Amount = productsForCurrentOrder.Sum(product => product.Amount);
+                }
+            }
+            return reportData;
+        }
+    }
+}

--- a/back_end/Application/Queries/GenerateAllCancelledOrdersReport.cs
+++ b/back_end/Application/Queries/GenerateAllCancelledOrdersReport.cs
@@ -4,10 +4,10 @@ using back_end.Domain;
 
 namespace back_end.Application.Queries {
     public class GenerateAllCancelledOrdersReport {
-        private readonly CancelledOrderReport cancelledOrderReport;
+        private readonly AllCancelledOrderReport cancelledOrderReport;
         public GenerateAllCancelledOrdersReport(
             IReportHandler reportHandler) {
-            cancelledOrderReport = new CancelledOrderReport(reportHandler);
+            cancelledOrderReport = new AllCancelledOrderReport(reportHandler);
         }
 
         public List<AdminReportOrderData> Execute(ReportBaseFilters baseFilters) {

--- a/back_end/Application/Reports/AllCancelledOrderReport.cs
+++ b/back_end/Application/Reports/AllCancelledOrderReport.cs
@@ -33,8 +33,8 @@ namespace back_end.Application.Reports {
                 pdfManager.AddTableHeader("Costo total de la compra");
 
                 foreach (var order in reportData) {
-                    pdfManager.AddTableBodyCell(order.UserID.ToString());
                     pdfManager.AddTableBodyCell(order.OrderID.ToString());
+                    pdfManager.AddTableBodyCell(order.UserID.ToString());
                     pdfManager.AddTableBodyCell(order.BusinessName ?? "N/A");
                     pdfManager.AddTableBodyCell(order.Amount.ToString());
                     pdfManager.AddTableBodyCell(order.CreatedDate?.ToString("dd/MM/yyyy") ?? "N/A");

--- a/back_end/Application/Reports/AllCancelledOrderReport.cs
+++ b/back_end/Application/Reports/AllCancelledOrderReport.cs
@@ -12,49 +12,41 @@ namespace back_end.Application.Reports {
             : base(reportHandler) {
         }
 
-        public override byte[] GeneratePdf(List<AdminReportOrderData> reportData) {
-            using (var memoryStream = new MemoryStream()) {
-                var document = new Document(PageSize.A4.Rotate(), 50, 50, 25, 25); // Recordar dar una explicacion de que son los numeros
-                PdfWriter.GetInstance(document, memoryStream);
-                document.Open();
+        public override byte[] GeneratePdf(List<AdminReportOrderData> reportData, ReportBaseFilters baseFilters) {
+            using (var pdfManager = new PDFManager()) {
+                pdfManager.AddTitle("Pedidos Cancelados por Tiempo");
+                pdfManager.AddParagraph($"Generado el: {DateTime.Now:dd/MM/yyyy HH:mm:ss}");
+                pdfManager.AddParagraph($"Fecha inicial del reporte: " + baseFilters.StartDate.ToShortDateString());
+                pdfManager.AddParagraph($"Fecha final del reporte: " + baseFilters.EndDate.ToShortDateString());
 
-                var titleFont = FontFactory.GetFont(FontFactory.TIMES_BOLD, 18);
-                var tableFont = FontFactory.GetFont(FontFactory.TIMES, 12);
+                var columnWidths = new float[] { 10, 15, 15, 15, 15, 15, 15, 15, 15 };
+                pdfManager.CreateTable(9, columnWidths);
 
-                document.Add(new Paragraph("Pedidos Cancelados por Tiempo", titleFont));
-                document.Add(new Paragraph($"Generado el: {DateTime.Now:dd/MM/yyy HH:mm:ss}", tableFont));
-                document.Add(new Paragraph("\n"));
-
-                var table = new PdfPTable(9) { WidthPercentage = 100 }; // 9 columnas
-                table.SetWidths(new float[] { 10, 10, 15, 10, 10, 15, 10, 10, 10 });
-
-                AddCellToHeader(table, "Número de orden");
-                AddCellToHeader(table, "ID de usuario");
-                AddCellToHeader(table, "Emprendimientos asociados");
-                AddCellToHeader(table, "Cantidad de items en la compra");
-                AddCellToHeader(table, "Fecha de creación");
-                AddCellToHeader(table, "Fecha de envío");
-                AddCellToHeader(table, "Costo total de los items");
-                AddCellToHeader(table, "Costo de envío");
-                AddCellToHeader(table, "Costo total de la compra");
+                pdfManager.AddTableHeader("Número de orden");
+                pdfManager.AddTableHeader("ID de usuario");
+                pdfManager.AddTableHeader("Emprendimientos asociados");
+                pdfManager.AddTableHeader("Cantidad de items en la compra");
+                pdfManager.AddTableHeader("Fecha de creación");
+                pdfManager.AddTableHeader("Fecha de envío");
+                pdfManager.AddTableHeader("Costo total de los items");
+                pdfManager.AddTableHeader("Costo de envío");
+                pdfManager.AddTableHeader("Costo total de la compra");
 
                 foreach (var order in reportData) {
-                    AddCellToBody(table, order.OrderID.ToString(), tableFont);
-                    AddCellToBody(table, order.UserID.ToString(), tableFont);
-                    AddCellToBody(table, order.BusinessName ?? "N/A", tableFont);
-                    AddCellToBody(table, order.Amount.ToString(), tableFont);
-                    AddCellToBody(table, order.CreatedDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
-                    AddCellToBody(table, order.DeliveryDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
-                    AddCellToBody(table, order.SubtotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
-                    AddCellToBody(table, order.DeliveryCost.ToString("C", new CultureInfo("es-CR")), tableFont);
-                    AddCellToBody(table, order.TotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
+                    pdfManager.AddTableBodyCell(order.UserID.ToString());
+                    pdfManager.AddTableBodyCell(order.OrderID.ToString());
+                    pdfManager.AddTableBodyCell(order.BusinessName ?? "N/A");
+                    pdfManager.AddTableBodyCell(order.Amount.ToString());
+                    pdfManager.AddTableBodyCell(order.CreatedDate?.ToString("dd/MM/yyyy") ?? "N/A");
+                    pdfManager.AddTableBodyCell(order.DeliveryDate?.ToString("dd/MM/yyyy") ?? "N/A");
+                    pdfManager.AddTableBodyCell("CRC " + order.SubtotalCost.ToString("#,##0.00", new CultureInfo("es-CR")));
+                    pdfManager.AddTableBodyCell("CRC " + order.DeliveryCost.ToString("#,##0.00", new CultureInfo("es-CR")));
+                    pdfManager.AddTableBodyCell("CRC " + order.TotalCost.ToString("#,##0.00", new CultureInfo("es-CR")));
 
                 }
 
-                document.Add(table);
-                document.Close();
-
-                return memoryStream.ToArray();
+                pdfManager.AddTableToDocument();
+                return pdfManager.GeneratePdf();
             }
         }
 

--- a/back_end/Application/Reports/AllCancelledOrderReport.cs
+++ b/back_end/Application/Reports/AllCancelledOrderReport.cs
@@ -7,8 +7,8 @@ using System.Data;
 using System.Globalization;
 
 namespace back_end.Application.Reports {
-    public class CancelledOrderReport : OrderReportTemplate<AdminReportOrderData> {
-        public CancelledOrderReport(IReportHandler reportHandler)
+    public class AllCancelledOrderReport : OrderReportTemplate<AdminReportOrderData> {
+        public AllCancelledOrderReport(IReportHandler reportHandler)
             : base(reportHandler) {
         }
 

--- a/back_end/Application/Reports/CancelledOrderReport.cs
+++ b/back_end/Application/Reports/CancelledOrderReport.cs
@@ -25,8 +25,8 @@ namespace back_end.Application.Reports {
                 document.Add(new Paragraph($"Generado el: {DateTime.Now:dd/MM/yyy HH:mm:ss}", tableFont));
                 document.Add(new Paragraph("\n"));
 
-                var table = new PdfPTable(10) { WidthPercentage = 100 }; // 10 columnas
-                table.SetWidths(new float[] { 10, 10, 15, 10, 10, 10, 15, 10, 10, 10 });
+                var table = new PdfPTable(9) { WidthPercentage = 100 }; // 9 columnas
+                table.SetWidths(new float[] { 10, 10, 15, 10, 10, 15, 10, 10, 10 });
 
                 AddCellToHeader(table, "Número de orden");
                 AddCellToHeader(table, "ID de usuario");
@@ -34,7 +34,6 @@ namespace back_end.Application.Reports {
                 AddCellToHeader(table, "Cantidad de items en la compra");
                 AddCellToHeader(table, "Fecha de creación");
                 AddCellToHeader(table, "Fecha de envío");
-                AddCellToHeader(table, "Fecha de recibido");
                 AddCellToHeader(table, "Costo total de los items");
                 AddCellToHeader(table, "Costo de envío");
                 AddCellToHeader(table, "Costo total de la compra");
@@ -46,7 +45,6 @@ namespace back_end.Application.Reports {
                     AddCellToBody(table, order.Amount.ToString(), tableFont);
                     AddCellToBody(table, order.CreatedDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
                     AddCellToBody(table, order.DeliveryDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
-                    AddCellToBody(table, order.ReceivedDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
                     AddCellToBody(table, order.SubtotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
                     AddCellToBody(table, order.DeliveryCost.ToString("C", new CultureInfo("es-CR")), tableFont);
                     AddCellToBody(table, order.TotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
@@ -62,7 +60,7 @@ namespace back_end.Application.Reports {
 
         protected override DataTable ExecuteReportQuery(ReportBaseFilters baseFilters) {
             string query = @"SELECT [o].OrderID, [o].ClientID, [o].CreatedDate, [o].DeliveryDate,
-                            [o].ReceivedDate, [o].SubtotalCost, [o].DeliveryCost, [o].TotalCost
+                            [o].SubtotalCost, [o].DeliveryCost, [o].TotalCost
                             FROM [Orders] [o]
                             WHERE [o].StatusChangeDate BETWEEN @StartDate AND @EndDate
                             AND [o].Status = 'Rechazada'";
@@ -75,7 +73,6 @@ namespace back_end.Application.Reports {
                 UserID = Convert.ToInt32(row["ClientID"]),
                 CreatedDate = row["CreatedDate"] != DBNull.Value ? Convert.ToDateTime(row["CreatedDate"]) : null,
                 DeliveryDate = row["DeliveryDate"] != DBNull.Value ? Convert.ToDateTime(row["DeliveryDate"]) : null,
-                ReceivedDate = row["ReceivedDate"] != DBNull.Value ? Convert.ToDateTime(row["ReceivedDate"]) : null,
                 SubtotalCost = row["SubtotalCost"] != DBNull.Value ? Convert.ToDecimal(row["SubtotalCost"]) : 0,
                 DeliveryCost = row["DeliveryCost"] != DBNull.Value ? Convert.ToDecimal(row["DeliveryCost"]) : 0,
                 TotalCost = row["TotalCost"] != DBNull.Value ? Convert.ToDecimal(row["TotalCost"]) : 0

--- a/back_end/Application/Reports/CancelledOrderReport.cs
+++ b/back_end/Application/Reports/CancelledOrderReport.cs
@@ -1,0 +1,85 @@
+﻿using back_end.Application.Interfaces;
+using back_end.Domain;
+using back_end.Infrastructure.Repositories;
+using iTextSharp.text;
+using iTextSharp.text.pdf;
+using System.Data;
+using System.Globalization;
+
+namespace back_end.Application.Reports {
+    public class CancelledOrderReport : OrderReportTemplate<AdminReportOrderData> {
+        public CancelledOrderReport(IReportHandler reportHandler)
+            : base(reportHandler) {
+        }
+
+        public override byte[] GeneratePdf(List<AdminReportOrderData> reportData) {
+            using (var memoryStream = new MemoryStream()) {
+                var document = new Document(PageSize.A4.Rotate(), 50, 50, 25, 25); // Recordar dar una explicacion de que son los numeros
+                PdfWriter.GetInstance(document, memoryStream);
+                document.Open();
+
+                var titleFont = FontFactory.GetFont(FontFactory.TIMES_BOLD, 18);
+                var tableFont = FontFactory.GetFont(FontFactory.TIMES, 12);
+
+                document.Add(new Paragraph("Pedidos Cancelados por Tiempo", titleFont));
+                document.Add(new Paragraph($"Generado el: {DateTime.Now:dd/MM/yyy HH:mm:ss}", tableFont));
+                document.Add(new Paragraph("\n"));
+
+                var table = new PdfPTable(10) { WidthPercentage = 100 }; // 10 columnas
+                table.SetWidths(new float[] { 10, 10, 15, 10, 10, 10, 15, 10, 10, 10 });
+
+                AddCellToHeader(table, "Número de orden");
+                AddCellToHeader(table, "ID de usuario");
+                AddCellToHeader(table, "Emprendimientos asociados");
+                AddCellToHeader(table, "Cantidad de items en la compra");
+                AddCellToHeader(table, "Fecha de creación");
+                AddCellToHeader(table, "Fecha de envío");
+                AddCellToHeader(table, "Fecha de recibido");
+                AddCellToHeader(table, "Costo total de los items");
+                AddCellToHeader(table, "Costo de envío");
+                AddCellToHeader(table, "Costo total de la compra");
+
+                foreach (var order in reportData) {
+                    AddCellToBody(table, order.OrderID.ToString(), tableFont);
+                    AddCellToBody(table, order.UserID.ToString(), tableFont);
+                    AddCellToBody(table, order.BusinessName ?? "N/A", tableFont);
+                    AddCellToBody(table, order.Amount.ToString(), tableFont);
+                    AddCellToBody(table, order.CreatedDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
+                    AddCellToBody(table, order.DeliveryDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
+                    AddCellToBody(table, order.ReceivedDate?.ToString("dd/MM/yyy") ?? "N/A", tableFont);
+                    AddCellToBody(table, order.SubtotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
+                    AddCellToBody(table, order.DeliveryCost.ToString("C", new CultureInfo("es-CR")), tableFont);
+                    AddCellToBody(table, order.TotalCost.ToString("C", new CultureInfo("es-CR")), tableFont);
+
+                }
+
+                document.Add(table);
+                document.Close();
+
+                return memoryStream.ToArray();
+            }
+        }
+
+        protected override DataTable ExecuteReportQuery(ReportBaseFilters baseFilters) {
+            string query = @"SELECT [o].OrderID, [o].ClientID, [o].CreatedDate, [o].DeliveryDate,
+                            [o].ReceivedDate, [o].SubtotalCost, [o].DeliveryCost, [o].TotalCost
+                            FROM [Orders] [o]
+                            WHERE [o].StatusChangeDate BETWEEN @StartDate AND @EndDate
+                            AND [o].Status = 'Rechazada'";
+            return _reportHandler.FetchReportOrderData(query, baseFilters);
+        }
+
+        protected override AdminReportOrderData MapOrderData(DataRow row) {
+            return new AdminReportOrderData {
+                OrderID = Convert.ToInt32(row["OrderID"]),
+                UserID = Convert.ToInt32(row["ClientID"]),
+                CreatedDate = row["CreatedDate"] != DBNull.Value ? Convert.ToDateTime(row["CreatedDate"]) : null,
+                DeliveryDate = row["DeliveryDate"] != DBNull.Value ? Convert.ToDateTime(row["DeliveryDate"]) : null,
+                ReceivedDate = row["ReceivedDate"] != DBNull.Value ? Convert.ToDateTime(row["ReceivedDate"]) : null,
+                SubtotalCost = row["SubtotalCost"] != DBNull.Value ? Convert.ToDecimal(row["SubtotalCost"]) : 0,
+                DeliveryCost = row["DeliveryCost"] != DBNull.Value ? Convert.ToDecimal(row["DeliveryCost"]) : 0,
+                TotalCost = row["TotalCost"] != DBNull.Value ? Convert.ToDecimal(row["TotalCost"]) : 0
+            };
+        }
+    }
+}

--- a/back_end/Domain/AdminReportOrderData.cs
+++ b/back_end/Domain/AdminReportOrderData.cs
@@ -1,0 +1,7 @@
+﻿namespace back_end.Domain {
+    public class AdminReportOrderData : ReportOrderData {
+        public DateTime? DeliveryDate { get; set; }
+        public DateTime? ReceivedDate { get; set; }
+        public int? UserID { get; set; }
+    }
+}

--- a/back_end/Program.cs
+++ b/back_end/Program.cs
@@ -59,6 +59,8 @@ builder.Services.AddScoped<SqlConnection>(auxiliarVariable => new SqlConnection(
 //Reports Dependencies
 builder.Services.AddScoped<GenerateCompletedOrdersReport>();
 builder.Services.AddScoped<GenerateCompletedOrderReportPDF>();
+builder.Services.AddScoped<GenerateAllCancelledOrdersReport>();
+builder.Services.AddScoped<GenerateAllCancelledOrderReportPDF>();
 builder.Services.AddScoped<IReportHandler, ReportHandler>();
 
 var app = builder.Build();

--- a/back_end/Program.cs
+++ b/back_end/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddScoped<GenerateAllCancelledOrdersReport>();
 builder.Services.AddScoped<GenerateAllCancelledOrderReportPDF>();
 builder.Services.AddScoped<IReportHandler, ReportHandler>();
 builder.Services.AddScoped<OrderReportTemplate<ReportCompletedOrderData>, CompletedOrderReport>();
+builder.Services.AddScoped<OrderReportTemplate<AdminReportOrderData>, AllCancelledOrderReport>();
 
 var app = builder.Build();
 

--- a/front-end/src/components/AdminNavbar.vue
+++ b/front-end/src/components/AdminNavbar.vue
@@ -10,6 +10,10 @@
                     <b-nav-item href="/AdminViewAllBusiness">Ver todas las empresas registradas</b-nav-item>
                     <b-nav-item href="/UserList">Ver todos los usuarios</b-nav-item>
                     <b-nav-item href="/confirmarOrdenes">Revisar ordenes entrantes</b-nav-item>
+
+                    <b-nav-item-dropdown text="Reportes">
+                        <b-dropdown-item href="/AdminReports/Cancelled">Canceladas</b-dropdown-item>
+                    </b-nav-item-dropdown>
                 </b-navbar-nav>
 
                 <b-navbar-nav class="ms-auto">

--- a/front-end/src/components/AdminRejectsReport.vue
+++ b/front-end/src/components/AdminRejectsReport.vue
@@ -1,0 +1,169 @@
+<template>
+    <template v-if="isAdmin">
+        <AdminNavbar />
+        <h1 class="display-4 text-center mb-4"><strong>Generador de reportes de ordenes rechazadas</strong></h1>
+        <div>
+            <div class="text-center">
+                <label><strong>Periodo de reporte:</strong></label> <span />
+                <input v-model="startDate" type="date" name="startDate-selector" id="startDate-selector" @change="clearEndDate"> -
+                <input v-model="endDate" type="date" name="endDate-selector" :min="startDate" id="endDate-selector" :disabled="!startDate">
+                <span class="ms-2"/>
+
+                <button v-on:click="generateReport" class="btn btn-info" :disabled="!(startDate && endDate)">
+                    Generar reporte
+                </button> <span class="ms-3"/>
+
+                <button v-on:click="openWarningPDFModal" class="btn btn-success" :disabled="!isValidReport">
+                    Exportar a PDF
+                </button>
+            </div>
+        </div>
+        <template v-if="isValidReport">
+            <div class="table-responsive-sm">
+                <table class="table table-striped table-hover">
+                    <thead>
+                        <tr>
+                            <th scope="col">Número de orden</th>
+                            <th scope="col">ID de cliente</th>
+                            <th scope="col">Emprendimientos asociados</th>
+                            <th scope="col">Cantidad de Items en la compra</th>
+                            <th scope="col">Fecha de creación</th>
+                            <th scope="col">Fecha de envío</th>
+                            <th scope="col">Costo total de los items</th>
+                            <th scope="col">Costo de envío</th>
+                            <th scope="col">Costo total de los compra</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="order in orders" :key="order.orderID">
+                            <td>{{ order.orderID }}</td>
+                            <td>{{ order.userID }}</td>
+                            <td>{{ order.businessName }}</td>
+                            <td>{{ order.amount }}</td>
+                            <td>{{ formatDate(order.createdDate) }}</td>
+                            <td>{{ order.deliveryDate ? formatDate(order.deliveryDate) : '-' }}</td>
+                            <td class="text-end pe-5">₡ {{ order.subtotalCost }}</td>
+                            <td class="text-end pe-5">₡ {{ order.deliveryCost }}</td>
+                            <td class="text-end pe-5">₡ {{ order.totalCost }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <ActionModalWarning ref="warningPDFModal" @confirmed="generatePDF" />
+        </template>
+        <template v-else>
+            <br />
+            <h3 class="text-center mb-4">No ha seleccionado un periodo con órdenes que cumplan el criterio</h3>
+        </template>
+    </template>
+
+    <template v-else>
+        <h1 class="display-4 text-center mb-4"><strong>403 Forbidden</strong></h1>
+        <h3 class="text-center mb-4">Página solo para administradores <br /><a href="/">Regresar</a></h3>
+    </template>
+</template>
+
+<script>
+    import AdminNavbar from './AdminNavbar.vue';
+    import ActionModalWarning from './ActionModalWarning.vue';
+    import { BackendUrl } from '../main.js';
+    import axios from "axios";
+
+    export default {
+        components: {
+            AdminNavbar,
+            ActionModalWarning,
+        },
+        data() {
+            return {
+                startDate: null,
+                endDate: null,
+                isValidReport: false,
+                currentReportStartDate: null,
+                currentReportEndDate: null,
+                orders: [
+                    {
+                        orderID: 0,
+                        userID: 0,
+                        businessName: '',
+                        amount: 0,
+                        createdDate: '',
+                        deliveryDate: '',
+                        subtotalCost: 0,
+                        deliveryCost: 0,
+                        totalCost: 0,
+                    },
+                ],
+            };
+        },
+        methods: {
+            clearEndDate() {
+                if (this.startDate) {
+                    this.endDate = '';
+                }
+            },
+            generateReport() {
+                axios.get(`${BackendUrl}/Reports/CancelledOrders`, {
+                    params: {
+                        startDate: this.startDate,
+                        endDate: this.endDate
+                    }
+                })
+                .then((response) => {
+                    this.orders = response.data;
+                    this.isValidReport = true;
+                    this.currentReportStartDate = this.startDate;
+                    this.currentReportEndDate = this.endDate;
+                })
+                .catch((error) => {
+                    console.log(error);
+                });
+            },
+            openWarningPDFModal() {
+                this.$refs.warningPDFModal.openModal("Seguro de que desea generar un report en PDF?");
+            },
+            generatePDF() {
+                axios.get(`${BackendUrl}/Reports/CancelledOrders/pdf`, {
+                    params: {
+                        startDate: this.currentReportStartDate,
+                        endDate: this.currentReportEndDate
+                    },
+                    responseType: 'blob'
+                })
+                .then((response) => {
+                    const url = window.URL.createObjectURL(new Blob([response.data], { type: 'application/pdf' }));
+                    const link = document.createElement('a');
+                    link.href = url;
+                    link.download = `AllCancelledOrdersReport(${new Date().toLocaleDateString()}).pdf`;
+
+                    document.body.appendChild(link);
+                    link.click();
+                    window.URL.revokeObjectURL(url);
+                    document.body.removeChild(link);
+                })
+                .catch((error) => {
+                    console.log(error);
+                });
+            },
+            formatDate(dateString) {
+                const date = new Date(dateString);
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${day}/${month}/${year}`;
+            },
+        },
+        props: {
+            isAdmin: {
+                type: Boolean,
+                required: true,
+            },
+            isClient: {
+                type: Boolean,
+                required: true,
+            },
+        },
+    }
+</script>
+
+<style></style>

--- a/front-end/src/main.js
+++ b/front-end/src/main.js
@@ -23,6 +23,7 @@ import IndividualProductPage from './components/IndividualProductPage.vue';
 import MetodoPago from './components/MetodoPago.vue';
 import OrderConfirmation from './components/OrderConfirmation.vue';
 import CreateOrder from './components/CreateOrder.vue';
+import RejectsReport from './components/AdminRejectsReport.vue';
 
 import MyOrders from './components/MyOrders.vue';
 
@@ -50,6 +51,7 @@ const router = createRouter({
         { path: "/ConfirmarOrdenes", name: "Confirmacion de ordenes", component: OrderConfirmation },
         { path: "/Orden", name: "Orden", component: CreateOrder },
         { path: "/MisOrdenes", name: "Mis ordenes", component: MyOrders },
+        { path: "/AdminReports/Cancelled", name: "Ordenes canceladas", component: RejectsReport },
     ],
 });
 


### PR DESCRIPTION
Se permite a un administrador generar reportes de todas las ordenes que fueron rechazadas y le permite exportar estos reportes a pdf, la ruta para esta página es /AdminReports/Cancelled
Se tomaron todas las verificaciones necesarias para no permitir que se pueda seleccionar una fecha final posterior a la fecha de inicio.